### PR TITLE
change return type to str, not Path

### DIFF
--- a/deepbinner/deepbinner.py
+++ b/deepbinner/deepbinner.py
@@ -330,13 +330,13 @@ def find_model(model_name):
     try:
         start_model = pathlib.Path(__file__).parents[1] / 'models' / model_name
         if start_model.is_file():
-            return start_model
+            return str(start_model)
     except IndexError:
         pass
     try:
         start_model = pathlib.Path(__file__).parents[0] / 'models' / model_name
         if start_model.is_file():
-            return start_model
+            return str(start_model)
     except IndexError:
         pass
     sys.exit('Error: could not find {} - did Deepbinner install correctly?'.format(model_name))


### PR DESCRIPTION
the `keras.load_model` function requires a string and this function returns a Path object. I've altered it to return a string, which is what downstream functions seem to expect anyway. This should address issue #9, hopefully.